### PR TITLE
Update retropielcdfirst.sh

### DIFF
--- a/retropielcdfirst.sh
+++ b/retropielcdfirst.sh
@@ -31,6 +31,7 @@ if [ "1" = $HDMI_HPD_VALUE  ]; then
 			#echo " defaults.ctl.card 0" >> $File
 			echo "HDMI ADUIO enabled."
 		fi
+		sudo cp -f "/boot/config.txt" "/boot/config_lcd.txt"
 		sudo rm -f /boot/config.txt
 		sudo cp -f "/boot/config_hdmi.txt" "/boot/config.txt"
 		sudo shutdown -r now  


### PR DESCRIPTION
When going back from HDMI to LCD the script use a file call "config_lcd.txt" and rename it "config.txt" (this file should have LCD screen config) :

on line 53 : sudo cp -f "/boot/config_lcd.txt" "/boot/config.txt"

The issue is that there is no "config_lcd.txt" file. 
Adding a backup file of LCD screen "config.txt" name "config_lcd.txt" when switching for LCD to HDMI :

line 34 : sudo cp -f "/boot/config.txt" "/boot/config_lcd.txt"