### PR TITLE
Update retropie_SafeShutdown_gpi2.py to exit ES cleanly

### DIFF
--- a/retropie_SafeShutdown_gpi2.py
+++ b/retropie_SafeShutdown_gpi2.py
@@ -25,8 +25,8 @@ def poweroff():
 	while True:
 		#self.assertEqual(GPIO.input(powerPin), GPIO.LOW)
 		GPIO.wait_for_edge(powerPin, GPIO.FALLING)
-		os.system("sudo killall emulationstation")
-		os.system("sudo killall emulationstatio") #RetroPie 4.6
+		os.system("sudo killall -SIGTERM emulationstation")
+		os.system("sudo killall -SIGTERM emulationstatio") #RetroPie 4.6
 		os.system("sudo sleep 5s")
 		os.system("sudo shutdown -h now")
 def lcdrun():


### PR DESCRIPTION
Adding -SIGTERM to the killall command exits Emulation Station cleanly. Without this, it won't save configurations it stores in memory and writes to disk on a clean exit (like Last Played).

Didn't look at the other scripts, but I suspect it will apply to anything that uses EmulationStation.